### PR TITLE
Di 2416 uranus qc workbook config v2.1.0.json

### DIFF
--- a/MYE_config/uranus_qc_workbook_config_v2.1.0.json
+++ b/MYE_config/uranus_qc_workbook_config_v2.1.0.json
@@ -5,7 +5,8 @@
     "details": "Includes cell locations to  add data to",
     "changelog": {
         "v1.0.0": "Initial working version",
-        "v2.0.0": "Compatible with new capture and generate_workbook_v2.10 format"
+        "v2.0.0": "Compatible with new capture and generate_workbook_v2.10 format",
+        "v2.1.0": "Compatible with generate_workbook_v2.11.1 format"
     },
     "cell_locations": {
         "250_coverage": "B9",

--- a/MYE_config/uranus_qc_workbook_config_v2.1.0.json
+++ b/MYE_config/uranus_qc_workbook_config_v2.1.0.json
@@ -1,7 +1,7 @@
 {
     "name": "Config for eggd_multiqc_to_workbook",
     "assay_version": "MYE v3.0.0",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "details": "Includes cell locations to  add data to",
     "changelog": {
         "v1.0.0": "Initial working version",

--- a/MYE_config/uranus_qc_workbook_config_v2.1.0.json
+++ b/MYE_config/uranus_qc_workbook_config_v2.1.0.json
@@ -5,7 +5,7 @@
     "details": "Includes cell locations to  add data to",
     "changelog": {
         "v1.0.0": "Initial working version",
-        "v2.0.0": "Copatible with new capture and generate_workbook_v2.10 format"
+        "v2.0.0": "Compatible with new capture and generate_workbook_v2.10 format"
     },
     "cell_locations": {
         "250_coverage": "B9",

--- a/MYE_config/uranus_qc_workbook_config_v2.1.0.json
+++ b/MYE_config/uranus_qc_workbook_config_v2.1.0.json
@@ -7,20 +7,19 @@
         "v1.0.0": "Initial working version",
         "v2.0.0": "Copatible with new capture and generate_workbook_v2.10 format"
     },
-    "cell_locations":{
-        "250_coverage":"B15",
-        "freemix":"B16",
-        "M_reads": "B17",
-        "fold_80":"B18",
-        "insert_size": "B19",
-        "somalier": "B20",
-        "somalier_text":"A20"
+    "cell_locations": {
+        "250_coverage": "B9",
+        "freemix": "B10",
+        "M_reads": "B11",
+        "fold_80": "B12",
+        "insert_size": "B13",
+        "somalier": "B14",
+        "somalier_text": "A14"
     },
-    "multiqc_file_names":{
-        "general_stats_file":"multiqc_general_stats.txt",
+    "multiqc_file_names": {
+        "general_stats_file": "multiqc_general_stats.txt",
         "hsmetrics_file": "multiqc_picard_HsMetrics.txt",
         "sexcheck_file": "multiqc_sex_check.txt",
         "somalier_file": "multiqc_somalier_sex_check.txt"
     }
-
 }


### PR DESCRIPTION
- Bump version
- Typo fix
- Update the fields for the QC summary sheet to be compatible with eggd_generate_variant_workbook v2.11.1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc_to_workbooks_config/3)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Updated QC workbook configuration to version 2.1.0, compatible with the latest workbook format (v2.11.1).
  - Adjusted cell locations for key metrics (250x coverage, freemix, M_reads, fold_80, insert_size, somalier) to align with the new layout.
- Chores
  - Removed the legacy configuration superseded by the new version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->