### PR TITLE
Updated name of sexcheck_file

### DIFF
--- a/MYE_config/uranus_qc_workbook_config_v2.1.1.json
+++ b/MYE_config/uranus_qc_workbook_config_v2.1.1.json
@@ -1,12 +1,13 @@
 {
     "name": "Config for eggd_multiqc_to_workbook",
     "assay_version": "MYE v3.0.0",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "details": "Includes cell locations to  add data to",
     "changelog": {
         "v1.0.0": "Initial working version",
         "v2.0.0": "Compatible with new capture and generate_workbook_v2.10 format",
-        "v2.1.0": "Compatible with generate_workbook_v2.11.1 format"
+        "v2.1.0": "Compatible with generate_workbook_v2.11.1 format",
+        "v2.1.1": "Updated name of sexcheck_file"
     },
     "cell_locations": {
         "250_coverage": "B9",
@@ -20,7 +21,7 @@
     "multiqc_file_names": {
         "general_stats_file": "multiqc_general_stats.txt",
         "hsmetrics_file": "multiqc_picard_HsMetrics.txt",
-        "sexcheck_file": "multiqc_sex_check.txt",
+        "sexcheck_file": "multiqc_sex_check_table.txt",
         "somalier_file": "multiqc_somalier_sex_check.txt"
     }
 }


### PR DESCRIPTION
The name of the target file has changed following an update to MultiQC.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_multiqc_to_workbooks_config/4)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**v2.1.1 - Patch Release**

* **Bug Fixes**
  * Updated sex check file reference path to use the correct data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->